### PR TITLE
code cleanup

### DIFF
--- a/plugins/karma.rb
+++ b/plugins/karma.rb
@@ -3,40 +3,33 @@ require 'cinch'
 class Karma
   include Cinch::Plugin
 
-  match /((\S+)[\+\?]{2})/
-
   def initialize(*args)
     super
     @users = Hash.new(0)
   end
 
-  def points_message(nick)
-    return "#{ nick } has #{ @users[nick] } awesome points."
+  match /(\S+)[\+]{2}/, method: :increment
+  def increment(m, nick)
+    if nick == @bot.nick
+      m.reply "Increasing my karma would result in overflow."
+    elsif nick == m.user.nick
+      m.reply "Just keep patting yourself on the back there, sport."
+    else
+      @users[nick] += 1
+      score(m, nick)
+    end
   end
 
-  def execute(m)
-    cmd = m.params[1]
-    tokens = cmd.match(/[!](\S+)([\+\?]{2})/)
-    nick = tokens[1]
-    action = tokens[2]
-    
-    if action == '++'
-      if nick == @bot.nick
-        m.reply "Increasing my karma would result in overflow."
-      elsif nick == m.user.nick
-        m.reply "Just keep patting yourself on the back there, sport."
-      else
-        @users[nick] += 1
-        m.reply points_message(nick)
-      end
-    elsif action == '??'
-      if nick == 'karma'
-        @users.each do |nick, points|
-          m.reply points_message(nick)
-        end
-      else
-        m.reply points_message(nick)
-      end
+  match /karma\?(\s+)?(\S+)?/, method: :scores
+  def scores(m, cmd, nick)
+    if nick
+      score(m, nick)
+    else
+      @users.each { |nick, score| score(m, nick) }
     end
+  end
+  
+  def score(m, nick)
+    m.reply "#{ nick } has #{ @users[nick] } awesome points."
   end
 end


### PR DESCRIPTION
The query command now works as follows:

!karma?
displays scores for every user (possibly flooding the channel, but eh)

!karma? <nick>
displays scores for the specified user

Fixed the regex for increment command, and got rid of double-passing.
